### PR TITLE
Change mod group/.jar name in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 version = "1.2"
-group= "fr.dbrown55.utilmod" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "dbrownutil"
+group= "fr.dbrown55.concrete" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = "concretemod"
 
 sourceCompatibility = targetCompatibility = "1.6" // Need this here so eclipse task generates correctly.
 compileJava {


### PR DESCRIPTION
Just made sure to change the mod's archive name as well as change the group to the actual concrete mod path.  It already has dbrownutil as a dependency, so that should be fine.